### PR TITLE
Error when using the gulp watch command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,8 +41,8 @@ gulp.task('js:production', function() {
 });
 
 gulp.task('watch', function() {
-  gulp.watch(['./assets/css/**/*.styl'], 'css:development');
-  gulp.watch(['./assets/css/**/*.js'], 'js:development');
+  gulp.watch('./assets/css/**/*.styl', ['css:development']);
+  gulp.watch('./assets/css/**/*.js', ['js:development']);
 });
 
 gulp.task('default', [


### PR DESCRIPTION
Fixing the "TypeError: Arguments to path.resolve must be strings" error when using `gulp watch`